### PR TITLE
Fix non-integer vertex count in call to igraph

### DIFF
--- a/R/dNetConfidence.r
+++ b/R/dNetConfidence.r
@@ -14,11 +14,11 @@
 #' @include dNetConfidence.r
 #' @examples
 #' # 1) generate a target graph according to the ER model
-#' g <- erdos.renyi.game(100, 1/100)
+#' g <- sample_gnp(100, 1/100)
 #' target <- dNetInduce(g, V(g), knn=0)
 #'
 #' # 2) generate a list source graphs according to the ER model
-#' sources <- lapply(1:100, function(x) erdos.renyi.game(100*runif(1), 1/10))
+#' sources <- lapply(1:100, function(x) sample_gnp(sample(1:100, 1), 1/10))
 #'
 #' # 3) append the confidence information from the source graphs into the target graph
 #' g <- dNetConfidence(target=target, sources=sources)


### PR DESCRIPTION
This fixes an example where the `erdos.renyi.game()` igraph function was passed a non-integer vertex count. This will trigger an error in igraph 2.0.0, causing this package's checks to fail.

Additionally, this PR replaces the deprecated `erdos.renyi.game()` with `sample_gnp()`.

igraph 2.0.0 is scheduled for release on January 12.

Would you be able to install the igraph release candidate using `pak::pak("igraph/rigraph") ` and check if there are other issues? Thank you for your help!

CC @krlmlr

This should fix #4